### PR TITLE
huashan: blobs.mk: Fix missing liboemcamera reference

### DIFF
--- a/huashan/huashan-vendor-blobs.mk
+++ b/huashan/huashan-vendor-blobs.mk
@@ -166,6 +166,7 @@ PRODUCT_COPY_FILES += \
     vendor/sony/huashan/proprietary/lib/libmmjpeg.so:system/lib/libmmjpeg.so \
     vendor/sony/huashan/proprietary/lib/libmmstillomx.so:system/lib/libmmstillomx.so \
     vendor/sony/huashan/proprietary/lib/libnetmgr.so:system/lib/libnetmgr.so \
+    vendor/sony/huashan/proprietary/lib/liboemcamera.so:system/lib/liboemcamera.so \
     vendor/sony/huashan/proprietary/lib/libpin-cache.so:system/lib/libpin-cache.so \
     vendor/sony/huashan/proprietary/lib/libprotobuf-c.so:system/lib/libprotobuf-c.so \
     vendor/sony/huashan/proprietary/lib/libqcci_legacy.so:system/lib/libqcci_legacy.so \


### PR DESCRIPTION
 * Mistake from I449e4ac075fa089c0d3f63dead1745310b6cf3cb